### PR TITLE
fix getOsName and getOsVersion on Linux

### DIFF
--- a/src/sysinfo.nim
+++ b/src/sysinfo.nim
@@ -172,12 +172,12 @@ when defined(linux):
   proc getOsName*(): string =
     for line in readFile("/etc/os-release").split("\n"):
       if line.startsWith("NAME="):
-        return line[6..^2]
+        return line[5..^1].strip(chars={'"', '\''})
 
   proc getOsVersion*(): string =
     for line in readFile("/etc/os-release").split("\n"):
       if line.startsWith("VERSION_ID="):
-        return line[12..^2]
+        return line[11..^1].strip(chars={'"', '\''})
 
   proc getOsSerialNumber*(): string =
     readFile("/sys/devices/virtual/dmi/id/product_serial").strip()


### PR DESCRIPTION
Values in my /etc/os-release may be unquoted as long as there is no whitespace in them, thus I would get broken output from those two functions.

NB: Freedesktop spec allows both double and single quotes (as the file is intended to be source-able by shells that often support both quoting methods).

Before:

```
$ cat /etc/os-release | grep -e "VERSION_ID=" -e "^NAME="
NAME=Fedora
VERSION_ID=32

getOsName: edor
getOsVersion: 

$ cat /etc/os-release | grep -e "VERSION_ID=" -e "^NAME="
NAME="Fedora"
VERSION_ID="32"

$ nimcr test.nim 
getOsName: Fedora
getOsVersion: 32
```

After:

```
$ cat /etc/os-release | grep -e "VERSION_ID=" -e "^NAME="
NAME=Fedora
VERSION_ID=32

$ nimcr test.nim 
getOsName: Fedora
getOsVersion: 32

$ cat /etc/os-release | grep -e "VERSION_ID=" -e "^NAME="
NAME="Fedora"
VERSION_ID="32"

$ nimcr test.nim 
getOsName: Fedora
getOsVersion: 32
```