### PR TITLE
Replace WMIC with Powershell Equivalent

### DIFF
--- a/sysinfo.nimble
+++ b/sysinfo.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.1"
+version       = "0.2.2"
 author        = "Andre von Houck"
 description   = "System info, CPU, OS, Memory"
 license       = "MIT"


### PR DESCRIPTION
Addresses issues #9 and #10 related to WMIC being deprecated on modern windows. Uses powershell equivalent Get-CimInstance instead.